### PR TITLE
feat: Add E2E tests and GitHub Actions workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,45 @@
+name: E2E Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18' # Or your preferred Node.js version
+
+      - name: Install root dependencies (if any)
+        run: npm install --if-present
+
+      - name: Build dev package
+        run: npm run build --prefix dev
+
+      - name: Build prod package
+        run: npm run build --prefix prod
+
+      - name: Install e2e-tests dependencies (includes test-app links)
+        run: npm install --prefix e2e-tests
+
+      # Attempt to install test-app dependencies.
+      # This might fail or not work as expected due to file: linking complexities
+      # or if the e2e-tests/test-app/package.json was not fully populated by a SvelteKit scaffold.
+      # However, the crucial part is that e2e-tests itself has its dependencies.
+      - name: Install test-app dependencies (best effort)
+        run: npm install --prefix e2e-tests/test-app --if-present
+        continue-on-error: true # Allow this to fail as it might not be critical if tests can run against linked packages
+
+      - name: Run E2E tests
+        run: npm test --prefix e2e-tests
+        env:
+          CI: true # Common environment variable for CI environments
+          # Add any other environment variables your tests might need
+          # For example, if the server needs to run on a specific port in CI:
+          # PORT: 3000 # Or whatever port your test server is configured for
+        # Increase timeout for the test step if needed, Jest tests with server startup can be slow
+        # timeout-minutes: 15

--- a/e2e-tests/jest.config.js
+++ b/e2e-tests/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^\\$lib/(.*)$': '<rootDir>/src/lib/$1',
+  },
+};

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "e2e-tests",
+  "version": "1.0.0",
+  "description": "E2E tests for vite-plugin-sveltekit-telephone",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest",
+    "install-test-app": "cd test-app && npm install"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.3.3",
+    "axios": "^1.6.0"
+  },
+  "dependencies": {
+    "vite-plugin-sveltekit-telephone-dev": "file:../dev",
+    "vite-plugin-sveltekit-telephone-prod": "file:../prod"
+  }
+}

--- a/e2e-tests/src/e2e.spec.ts
+++ b/e2e-tests/src/e2e.spec.ts
@@ -1,0 +1,190 @@
+import axios from 'axios';
+import { spawn, ChildProcess } from 'child_process';
+import * as path from 'path';
+
+const BASE_URL = 'http://localhost:5173'; // Default Vite port
+const RPC_ENDPOINT = `${BASE_URL}/telephone`;
+
+describe('E2E RPC Tests', () => {
+  let devServer: ChildProcess;
+  let serverReady = false;
+  let serverErrorOutput = '';
+
+  beforeAll((done) => {
+    const testAppDir = path.resolve(__dirname, '../test-app');
+    // Try to run npm install first, then run dev
+    // Note: Due to sandbox limitations, this might not work as expected if npm install fails silently.
+    devServer = spawn('npm', ['run', 'dev'], {
+      cwd: testAppDir,
+      shell: true,
+      stdio: ['ignore', 'pipe', 'pipe'], // ignore stdin, pipe stdout and stderr
+    });
+
+    devServer.stdout?.on('data', (data) => {
+      process.stdout.write(`[test-app server stdout]: ${data}`);
+      if (data.toString().includes('Network')) { // A common message when Vite server is ready
+        serverReady = true;
+        done();
+      }
+    });
+
+    devServer.stderr?.on('data', (data) => {
+      process.stderr.write(`[test-app server stderr]: ${data}`);
+      serverErrorOutput += data.toString();
+      // If server fails to start quickly, call done to not hang tests indefinitely
+      if (serverErrorOutput.includes('ERR_PNPM_RECURSIVE_RUN_FIRST') || serverErrorOutput.includes('error')) {
+        if (!serverReady) { // Only fail if not already ready
+          console.error('Server failed to start or encountered an error quickly.');
+        }
+      }
+    });
+
+    // Failsafe timeout in case server doesn't start or output expected message
+    setTimeout(() => {
+      if (!serverReady) {
+        console.warn("Dev server did not signal readiness within timeout. Proceeding with tests, but they might fail.");
+        done();
+      }
+    }, 25000); // 25 seconds timeout
+  });
+
+  afterAll(() => {
+    return new Promise<void>((resolve) => {
+      if (devServer) {
+        console.log('Stopping dev server...');
+        devServer.on('close', () => {
+          console.log('Dev server stopped.');
+          resolve();
+        });
+        // Try graceful exit first
+        if (devServer.pid) {
+            process.kill(devServer.pid, 'SIGTERM');
+        }
+        // Force kill if not exited after a short delay
+        setTimeout(() => {
+            if (!devServer.killed) {
+                devServer.kill('SIGKILL');
+            }
+        }, 5000);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  const callRpc = async (filePath: string, functionName: string, args: any[]) => {
+    if (!serverReady) {
+      // Wait a bit longer if server wasn't ready during beforeAll
+      await new Promise(resolve => setTimeout(resolve, 5000));
+      if (!serverReady) {
+        throw new Error('Test server is not ready. Aborting RPC call.');
+      }
+    }
+    return axios.post(RPC_ENDPOINT, {
+      filePath,
+      functionName,
+      args,
+    });
+  };
+
+  it('should call hello function and get a greeting', async () => {
+    const response = await callRpc('src/lib/tele/e2e.telephone.ts', 'hello', ['Tester']);
+    expect(response.status).toBe(200);
+    expect(response.data.result).toBe('Hello, Tester!');
+  });
+
+  it('should call add function and get the sum', async () => {
+    const response = await callRpc('src/lib/tele/e2e.telephone.ts', 'add', [5, 7]);
+    expect(response.status).toBe(200);
+    expect(response.data.result).toBe(12);
+  });
+
+  it('should call functionWithNoArgs and get the correct string', async () => {
+    const response = await callRpc('src/lib/tele/e2e.telephone.ts', 'functionWithNoArgs', []);
+    expect(response.status).toBe(200);
+    expect(response.data.result).toBe('No arguments here!');
+  });
+
+  it('should call functionWithOptionalArg with argument and get personalized greeting', async () => {
+    const response = await callRpc('src/lib/tele/e2e.telephone.ts', 'functionWithOptionalArg', ['User']);
+    expect(response.status).toBe(200);
+    expect(response.data.result).toBe('Hello, User!');
+  });
+
+  it('should call functionWithOptionalArg without argument and get default greeting', async () => {
+    const response = await callRpc('src/lib/tele/e2e.telephone.ts', 'functionWithOptionalArg', []);
+    expect(response.status).toBe(200);
+    expect(response.data.result).toBe('Hello, world!');
+  });
+
+  it('should handle errors from the RPC function', async () => {
+    try {
+      await callRpc('src/lib/tele/e2e.telephone.ts', 'errorFunction', []);
+    } catch (error: any) {
+      expect(error.response).toBeDefined();
+      // The actual error from the function is wrapped by the server
+      // The exact structure of error.response.data might depend on SvelteKit/Vite error handling
+      // For now, we check if the server responded with an error status (e.g., 500)
+      // and if the response data contains the error message.
+      // This might need adjustment based on actual error structure from prod package.
+      expect(error.response.status).toBeGreaterThanOrEqual(400); // Or specifically 500 if that's what prod returns
+      expect(error.response.data).toBeDefined();
+      expect(error.response.data.error).toBeDefined();
+      expect(error.response.data.error.message).toBe('This is a test error');
+    }
+  });
+
+  it('should handle calling a non-existent function', async () => {
+    try {
+      await callRpc('src/lib/tele/e2e.telephone.ts', 'nonExistentFunction', []);
+    } catch (error: any) {
+      expect(error.response).toBeDefined();
+      expect(error.response.status).toBeGreaterThanOrEqual(400);
+      expect(error.response.data).toBeDefined();
+      expect(error.response.data.error).toBeDefined();
+      expect(error.response.data.error.message).toContain('RPC function "src/lib/tele/e2e.telephone.ts:nonExistentFunction" not found');
+    }
+  });
+
+  it('should handle incorrect argument types for "hello" function', async () => {
+    try {
+      // Sending a number instead of a string for the 'name' argument
+      await callRpc('src/lib/tele/e2e.telephone.ts', 'hello', [123]);
+    } catch (error: any) {
+      expect(error.response).toBeDefined();
+      expect(error.response.status).toBeGreaterThanOrEqual(400);
+      expect(error.response.data).toBeDefined();
+      expect(error.response.data.error).toBeDefined();
+      expect(error.response.data.error.message).toContain('Invalid argument type for name: expected string, got number');
+    }
+  });
+
+  it('should handle incorrect argument types for "add" function', async () => {
+    try {
+      // Sending a string for the second argument
+      await callRpc('src/lib/tele/e2e.telephone.ts', 'add', [5, 'world']);
+    } catch (error: any) {
+      expect(error.response).toBeDefined();
+      expect(error.response.status).toBeGreaterThanOrEqual(400);
+      expect(error.response.data).toBeDefined();
+      expect(error.response.data.error).toBeDefined();
+      expect(error.response.data.error.message).toContain('Invalid arguments: a and b must be numbers');
+    }
+  });
+
+   it('should handle missing arguments for "add" function', async () => {
+    try {
+      await callRpc('src/lib/tele/e2e.telephone.ts', 'add', [5]);
+    } catch (error: any) {
+      expect(error.response).toBeDefined();
+      expect(error.response.status).toBeGreaterThanOrEqual(400); // Or specific code
+      expect(error.response.data).toBeDefined();
+      expect(error.response.data.error).toBeDefined();
+      // The exact error message for missing arguments might vary.
+      // The prod package's handleRoute might throw "TypeError: func is not a function" or similar if args don't match.
+      // Or it might be a "Cannot read properties of undefined" if the function tries to access a missing arg.
+      // For now, we check for a server error. This may need refinement.
+      expect(error.response.data.error.message).toBeDefined();
+    }
+  });
+});

--- a/e2e-tests/test-app/package.json
+++ b/e2e-tests/test-app/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "test-app",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-auto": "^3.0.0",
+    "@sveltejs/kit": "^2.0.0",
+    "@sveltejs/vite-plugin-svelte": "^3.0.0",
+    "svelte": "^4.2.7",
+    "svelte-check": "^3.6.0",
+    "tslib": "^2.4.1",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.3",
+    "vite-plugin-sveltekit-telephone-dev": "file:../../dev",
+    "vite-plugin-sveltekit-telephone-prod": "file:../../prod"
+  },
+  "type": "module"
+}

--- a/e2e-tests/test-app/src/app.html
+++ b/e2e-tests/test-app/src/app.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover">
+    <div style="display: contents">%sveltekit.body%</div>
+  </body>
+</html>

--- a/e2e-tests/test-app/src/hooks.server.ts
+++ b/e2e-tests/test-app/src/hooks.server.ts
@@ -1,0 +1,22 @@
+import { handleRoute } from 'vite-plugin-sveltekit-telephone-prod/server';
+import * as e2eFunctions from '$lib/tele/e2e.telephone';
+
+const functionMap = {
+  'src/lib/tele/e2e.telephone.ts': e2eFunctions
+};
+
+export const handle = async ({ event, resolve }: any) => {
+  if (event.url.pathname.startsWith('/telephone')) {
+    const body = await event.request.json();
+    const result = await handleRoute(functionMap, {
+      url: event.url.toString(),
+      body: body,
+      method: event.request.method,
+      context: {} // Add context if needed
+    });
+    return new Response(JSON.stringify(result), {
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+  return resolve(event);
+};

--- a/e2e-tests/test-app/src/lib/tele/e2e.telephone.ts
+++ b/e2e-tests/test-app/src/lib/tele/e2e.telephone.ts
@@ -1,0 +1,27 @@
+export function hello(name: string): string {
+  if (typeof name !== 'string') {
+    // @ts-ignore
+    throw new Error(`Invalid argument type for name: expected string, got ${typeof name}`);
+  }
+  return `Hello, ${name}!`;
+}
+
+export async function add(a: number, b: number): Promise<number> {
+  if (typeof a !== 'number' || typeof b !== 'number') {
+    // @ts-ignore
+    throw new Error('Invalid arguments: a and b must be numbers');
+  }
+  return a + b;
+}
+
+export function errorFunction(): void {
+  throw new Error('This is a test error');
+}
+
+export function functionWithNoArgs(): string {
+  return "No arguments here!";
+}
+
+export function functionWithOptionalArg(name?: string): string {
+  return `Hello, ${name || 'world'}!`;
+}

--- a/e2e-tests/test-app/src/routes/+page.svelte
+++ b/e2e-tests/test-app/src/routes/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import * as e2e from '$lib/tele/e2e.telephone';
+
+  let greeting = '';
+  let sum = 0;
+  let errorMessage = '';
+  let noArgsResult = '';
+  let optionalArgResult = '';
+
+  onMount(async () => {
+    try {
+      greeting = await e2e.hello('E2E Test');
+      sum = await e2e.add(2, 3);
+      noArgsResult = await e2e.functionWithNoArgs();
+      optionalArgResult = await e2e.functionWithOptionalArg();
+      await e2e.errorFunction(); // This will throw an error
+    } catch (err: any) {
+      errorMessage = err.message;
+    }
+  });
+</script>
+
+<h1>SvelteKit Test App</h1>
+<p data-testid="greeting">{greeting}</p>
+<p data-testid="sum">{sum}</p>
+<p data-testid="noArgsResult">{noArgsResult}</p>
+<p data-testid="optionalArgResult">{optionalArgResult}</p>
+<p data-testid="errorMessage">{errorMessage}</p>

--- a/e2e-tests/test-app/svelte.config.js
+++ b/e2e-tests/test-app/svelte.config.js
@@ -1,0 +1,12 @@
+import adapter from '@sveltejs/adapter-auto';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter()
+  }
+};
+
+export default config;

--- a/e2e-tests/test-app/tsconfig.json
+++ b/e2e-tests/test-app/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  }
+}

--- a/e2e-tests/test-app/vite.config.ts
+++ b/e2e-tests/test-app/vite.config.ts
@@ -1,0 +1,7 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig } from 'vite';
+import { telephoneDev } from 'vite-plugin-sveltekit-telephone-dev';
+
+export default defineConfig({
+  plugins: [sveltekit(), telephoneDev.plugin()]
+});

--- a/e2e-tests/tsconfig.json
+++ b/e2e-tests/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "baseUrl": ".",
+    "paths": {
+      "$lib/*": ["./src/lib/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "jest.config.js"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
- Created a new npm project `e2e-tests` for end-to-end testing.
- Manually scaffolded a minimal SvelteKit application within `e2e-tests/test-app` to serve as the testbed for RPC calls.
- Implemented E2E tests using Jest and Axios to:
  - Start the test SvelteKit application's dev server.
  - Make HTTP POST requests to the RPC endpoint.
  - Verify correct function calls and return values.
  - Check handling of errors and invalid arguments.
- Added a GitHub Actions workflow (`.github/workflows/e2e-tests.yml`) to automatically build the necessary packages and run the E2E tests on push and pull requests.